### PR TITLE
Fix COCO Dataset Loading for Invisible Keypoints

### DIFF
--- a/sleap/io/format/coco.py
+++ b/sleap/io/format/coco.py
@@ -180,6 +180,9 @@ class LabelsCocoAdaptor(Adaptor):
 
                 if flag == 0:
                     # node not labeled for this instance
+                    if (x, y) != (0, 0): 
+                        # If labeled but invisible, place the node at the coord
+                        points[node] = Point(x, y, False)
                     continue
 
                 is_visible = flag == 2


### PR DESCRIPTION
### Description
When loading COCO datasets, keypoints marked as invisible (flag=0) are currently skipped and later placed randomly within the instance's bounding box. However, in COCO format, these keypoints may still have valid coordinate information that should be preserved or are simply inconvenient to navigate while labeling other keypoints. See [toy_dataset](https://drive.google.com/drive/folders/1mvcJ7QuYxfgtaS5CaRsAzQbvHhaaA88g?usp=sharing) for images of expected vs. current behavior.

I added logic to:
- Check if invisible keypoints (flag=0) have non-zero coordinates
- If coordinates are (0,0), skip the point (existing behavior)
- If coordinates are not (0,0), create the point at those coordinates but mark it as not visible
- Maintain existing behavior for visible (flag=2) and labeled

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
No

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [x] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [x] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [x] Add tests that prove your fix is effective or that your feature works
- [x] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
